### PR TITLE
fix(pa.sh) more cross-distro compatible shebang

### DIFF
--- a/pa.sh
+++ b/pa.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export PASH_TOP=${PASH_TOP:-${BASH_SOURCE%/*}}
 export PASH_PARSER=${PASH_TOP}/parser/parse_to_json.native


### PR DESCRIPTION
In some cases (NixOS), /bin/bash doesn't exist. `#!/usr/bin/env bash` is generally more compatible.