### PR TITLE
Prefer UTF-8 encoding with read and generated UNIX50 files

### DIFF
--- a/evaluation/eurosys/generate_unix50_scripts.py
+++ b/evaluation/eurosys/generate_unix50_scripts.py
@@ -39,12 +39,12 @@ input_file_names = input_file_name_assignments.values()
 for input_file in input_file_names:
     input_file_path = os.path.join(unix50_dir, input_file)
     generated_input_file_path = os.path.join(generated_inputs_dir, input_file)
-    with open(input_file_path) as file:
+    with open(input_file_path, encoding='utf-8') as file:
         input_file_data = file.read()
 
     # print("Input:", input_file_path, "size:", len(input_file_data))
     num_iterations = maximum_input_size // len(input_file_data)
-    with open(generated_input_file_path, "w") as file:
+    with open(generated_input_file_path, "w", encoding='utf-8') as file:
         for _ in range(0, num_iterations, 100):
             file.write(input_file_data * 100)
 


### PR DESCRIPTION
`generate_unix50_scripts.py` fails with the following stack trace for `evaluation/unix50/8.txt`, when the system prefers the `ascii` codec.

```
Traceback (most recent call last):
  File "generate_unix50_scripts.py", line 44, in <module>
    input_file_data = file.read()
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 28011: ordinal not in range(128)
```

`cat unix50/8.txt | dd ibs=1 skip=28010 count=3` shows that the `ascii` codec tried to decode a Unicode cross character, which appears in a sentence about chessboard dimensions.

The root cause is that `open` will use a platform-specific default encoding, and `ascii` may be used in the context of a container. This seems incorrect given the input data, hence this patch.

I confirmed that with this patch, `execute_unix_benchmarks.sh` runs to completion when the platform prefers the `ascii` codec.