### PR TITLE
Performance test prototype

### DIFF
--- a/evaluation/eurosys/execute_unix_benchmarks.sh
+++ b/evaluation/eurosys/execute_unix_benchmarks.sh
@@ -31,7 +31,7 @@ results_subdir_prefix="unix50"
 
 if [ "$evaluation_level" -eq 1 ]; then
     echo "Executing Unix50 scripts with 1GB inputs and --width 4"
-    maximum_input_size="$((1024 * 1024 * 1024))" # 1 GB
+    maximum_input_size="$((1024 * 1024))" # 1 GB
     n_in=4
 elif [ "$evaluation_level" -eq 2 ]; then
     echo "Executing Unix50 scripts with 10GB inputs and --width 16"

--- a/evaluation/eurosys/execute_unix_benchmarks.sh
+++ b/evaluation/eurosys/execute_unix_benchmarks.sh
@@ -31,7 +31,7 @@ results_subdir_prefix="unix50"
 
 if [ "$evaluation_level" -eq 1 ]; then
     echo "Executing Unix50 scripts with 1GB inputs and --width 4"
-    maximum_input_size="$((1024 * 1024))" # 1 GB
+    maximum_input_size="$((1024 * 1024 * 1024))" # 1 GB
     n_in=4
 elif [ "$evaluation_level" -eq 2 ]; then
     echo "Executing Unix50 scripts with 10GB inputs and --width 16"

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -13,3 +13,9 @@ RUN sudo bash scripts/install.sh -p
 ENV PASH_TOP=/pash
 ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib/"
 CMD ["/bin/bash"]
+
+RUN apt-get update
+RUN apt-get install -y locales locales-all
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 RUN apt-get update -y
 RUN apt-get upgrade -y
-RUN apt-get install git sudo -y
+RUN apt-get install -y git sudo locales locales-all
 
 RUN git clone https://github.com/andromeda/pash.git
 WORKDIR "/pash"
@@ -10,12 +10,10 @@ WORKDIR "/pash"
 RUN sed -i 's#git@github.com:angelhof/libdash.git#https://github.com/angelhof/libdash/#g' .gitmodules
 RUN sudo bash scripts/install.sh -p
 
-ENV PASH_TOP=/pash
-ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib/"
-CMD ["/bin/bash"]
-
-RUN apt-get update
-RUN apt-get install -y locales locales-all
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
+
+ENV PASH_TOP=/pash
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib/"
+CMD ["/bin/bash"]

--- a/scripts/remote/README.md
+++ b/scripts/remote/README.md
@@ -127,6 +127,18 @@ are visible to the NGINX server using `scripts/pash-nginx.conf`*.
 
 ## Changelog
 
+### Jan 28 2021
+
+- Fix performance test configuration for Unix50 suite
+
+
+### Jan 27 2021
+
+- Add `controller/configs` directory
+- Resolve rcfile using `path.resolve` w.r.t controller directory.
+- Draft performance test configuration
+
+
 ### Jan 26 2021
 
 - Small refactor to allow configurable `/run` endpoint.

--- a/scripts/remote/README.md
+++ b/scripts/remote/README.md
@@ -129,6 +129,7 @@ are visible to the NGINX server using `scripts/pash-nginx.conf`*.
 
 ### Jan 28 2021
 
+- Add EuroSys one-liner suite to performance worker
 - Fix performance test configuration for Unix50 suite
 - Use directories for locks, since `mkdir` is atomic
 - Simplify `correctness-tests.js`

--- a/scripts/remote/README.md
+++ b/scripts/remote/README.md
@@ -130,6 +130,8 @@ are visible to the NGINX server using `scripts/pash-nginx.conf`*.
 ### Jan 28 2021
 
 - Fix performance test configuration for Unix50 suite
+- Use directories for locks, since `mkdir` is atomic
+- Simplify `correctness-tests.js`
 
 
 ### Jan 27 2021

--- a/scripts/remote/controller/command.js
+++ b/scripts/remote/controller/command.js
@@ -11,26 +11,14 @@ const path = require('path');
 
 const { NodeSSH } = require('node-ssh');
 
-const { hours, log, err, getRequestBody } = require('./lib.js');
+const { hours, log, err, getRequestBody, respond, getRemoteHomeDirectory, getSshCredentials } = require('./lib.js');
 const rc = require('./rc.js');
-
-const getSshCredentials = () => ({
-    host: rc('host', 'localhost'),
-    username: rc('user', process.env.USER),
-    privateKey: rc('private_key', `${process.env.HOME}/.ssh/id_rsa`),
-});
-
-const getRemoteHomeDirectory = () => {
-    const { username } = getSshCredentials();
-    return `/home/${username}`;
-};
 
 const sshConnect = async (username, host) => {
     const ssh = new NodeSSH();
     await ssh.connect(getSshCredentials());
     return ssh;
 };
-
 
 // The SSH commands do not actually wait for the commands to complete.
 // Current approach is to inspect the output to know when to proceed.

--- a/scripts/remote/controller/commands/correctness-tests.js
+++ b/scripts/remote/controller/commands/correctness-tests.js
@@ -1,32 +1,9 @@
-const Rsync = require('rsync');
-const { hours } = require('../lib.js');
+const { hours, syncRemoteDirectory } = require('../lib.js');
 
 module.exports = {
     makeCommandOptions: () => ({
         timeout: hours(1),
         shouldStopWaiting: (stdout, stderr) => /<<(fail|done)>>/.test(stdout),
-        postCompletion: async (ssh) => {
-            try {
-                // TODO: Stream rsync stdin/stdout to new files.
-                const rsync = (
-                    new Rsync()
-                        .flags('abziu')
-                        .set('e', `ssh -i ${rc('private_key')}`)
-                        .source(`${rc('user')}@${rc('host')}:reports/`) // Trailing '/' is meaningful: https://serverfault.com/a/529294
-                        .destination(rc('ci_reports_path', `${__dirname}/reports`))
-                );
-
-                await new Promise((resolve, reject) =>
-                    rsync.execute((error, code, cmd) => {
-                        if (error)
-                            reject(error)
-                        else
-                            resolve();
-                    }));
-            } catch (e) {
-                err(e);
-                throw e;
-            }
-        },
+        postCompletion: (ssh) => syncRemoteDirectory('reports', rc('ci_reports_path', `${__dirname}/reports`)),
     }),
 };

--- a/scripts/remote/controller/commands/correctness-tests.js
+++ b/scripts/remote/controller/commands/correctness-tests.js
@@ -1,4 +1,5 @@
 const { hours, syncRemoteDirectory } = require('../lib.js');
+const rc = require('../rc.js');
 
 module.exports = {
     makeCommandOptions: () => ({

--- a/scripts/remote/controller/commands/performance-tests.js
+++ b/scripts/remote/controller/commands/performance-tests.js
@@ -1,9 +1,12 @@
-const Rsync = require('rsync');
-const { hours } = require('../lib.js');
+const { hours, syncRemoteDirectory } = require('../lib.js');
+const rc = require('../rc.js');
 
 module.exports = {
     makeCommandOptions: () => ({
         timeout: hours(24),
-        shouldStopWaiting: (stdout, stderr) => true,
+        shouldStopWaiting: (stdout, stderr) => /<<(fail|done)>>/.test(stdout),
+        postCompletion: (ssh) => (
+            syncRemoteDirectory('results', rc('perf_results_path', `${__dirname}/perf_results`))
+        ),
     }),
 };

--- a/scripts/remote/controller/commands/performance-tests.js
+++ b/scripts/remote/controller/commands/performance-tests.js
@@ -1,0 +1,9 @@
+const Rsync = require('rsync');
+const { hours } = require('../lib.js');
+
+module.exports = {
+    makeCommandOptions: () => ({
+        timeout: hours(24),
+        shouldStopWaiting: (stdout, stderr) => true,
+    }),
+};

--- a/scripts/remote/controller/configs/performance-tests.json
+++ b/scripts/remote/controller/configs/performance-tests.json
@@ -1,0 +1,5 @@
+{
+    "port": 2048,
+    "command_module": "./commands/performance-tests.js",
+    "host": "memstar.ndr.md"
+}

--- a/scripts/remote/workers/run-ci.sh
+++ b/scripts/remote/workers/run-ci.sh
@@ -7,11 +7,12 @@
 set -e
 trap 'echo "<<fail>>"' ERR
 
-if [ -f lock ]; then
-  echo "Busy on existing job."
+if [ -d lock ]; then
+    echo "Busy on existing job."
+    echo "<<fail>>"
 else
-    touch lock
-    trap 'rm lock' EXIT
+    mkdir lock
+    trap 'rm -r lock' EXIT
     docker start pash-playground
     docker exec pash-playground bash -c 'cd /pash/scripts && ./ci.sh'
 

--- a/scripts/remote/workers/run-perf.sh
+++ b/scripts/remote/workers/run-perf.sh
@@ -4,8 +4,6 @@
 
 CONTAINER_NAME=pash-perf
 
-docker run -itd --name pash-perf pash bin/bash
-
 cleanup() {
   docker container stop $CONTAINER_NAME
   docker container rm $CONTAINER_NAME
@@ -14,6 +12,9 @@ cleanup() {
 run() {
   docker exec $CONTAINER_NAME /bin/bash -c "cd /pash/evaluation/eurosys && $@"
 }
+
+cleanup
+docker run -itd --name pash-perf pash /bin/bash
 
 trap 'cleanup' EXIT
 trap 'echo "<<fail>>"' ERR

--- a/scripts/remote/workers/run-perf.sh
+++ b/scripts/remote/workers/run-perf.sh
@@ -1,0 +1,43 @@
+#! /bin/bash
+
+CONTAINER_NAME=pash-perf
+
+#docker run -itd --name pash-perf pash bin/bash
+
+cleanup() {
+  docker container stop $CONTAINER_NAME
+  docker container rm $CONTAINER_NAME
+}
+
+run() {
+  docker exec $CONTAINER_NAME /bin/bash -c "cd /pash/evaluation/eurosys && $@"
+}
+
+#trap 'cleanup' EXIT
+trap 'echo "<<fail>>"' ERR
+
+if [ -f lock ]; then
+    echo "Busy on existing job."
+else
+    touch lock
+    trap 'rm lock' EXIT
+
+    #run ./execute_eurosys_one_liners.sh -s
+    run ./execute_unix_benchmarks.sh -s
+
+    ## Uncomment when ready to deal with large inputs.
+    # run execute_baseline_sort.sh
+    # run execute_max_temp_dish_evaluation.sh
+    # run execute_web_index_dish_evaluation.sh
+
+    # WARNING: If you are using the snap edition of Docker, this
+    # command may break at the start of a personalized rabbit hole.
+    #
+    # Do not delete the dots and slashes at the end of the arguments.
+    # They trigger desired merging behavior.
+    # https://github.com/moby/moby/issues/31251#issuecomment-281634234
+    docker cp "$CONTAINER_NAME:/pash/evaluation/results/." results/
+
+    # The controller looks for this.
+    echo '<<done>>'
+fi

--- a/scripts/remote/workers/run-perf.sh
+++ b/scripts/remote/workers/run-perf.sh
@@ -22,7 +22,7 @@ else
     touch lock
     trap 'rm lock' EXIT
 
-    #run ./execute_eurosys_one_liners.sh -s
+    run ./execute_eurosys_one_liners.sh -s
     run ./execute_unix_benchmarks.sh -s
 
     ## Uncomment when ready to deal with large inputs.

--- a/scripts/remote/workers/run-perf.sh
+++ b/scripts/remote/workers/run-perf.sh
@@ -27,7 +27,7 @@ else
 
     docker exec $CONTAINER_NAME /bin/bash -c "cd /pash && git pull"
     run ./execute_eurosys_one_liners.sh -m
-    run ./execute_unix_benchmarks.sh -m
+    run ./execute_unix_benchmarks.sh -l
 
     ## Uncomment when ready to deal with large inputs.
     # run execute_baseline_sort.sh

--- a/scripts/remote/workers/run-perf.sh
+++ b/scripts/remote/workers/run-perf.sh
@@ -1,8 +1,10 @@
 #! /bin/bash
 
+# Invariant: Docker image `pash` must exist.
+
 CONTAINER_NAME=pash-perf
 
-#docker run -itd --name pash-perf pash bin/bash
+docker run -itd --name pash-perf pash bin/bash
 
 cleanup() {
   docker container stop $CONTAINER_NAME
@@ -13,7 +15,7 @@ run() {
   docker exec $CONTAINER_NAME /bin/bash -c "cd /pash/evaluation/eurosys && $@"
 }
 
-#trap 'cleanup' EXIT
+trap 'cleanup' EXIT
 trap 'echo "<<fail>>"' ERR
 
 if [ -f lock ]; then
@@ -22,8 +24,9 @@ else
     touch lock
     trap 'rm lock' EXIT
 
-    run ./execute_eurosys_one_liners.sh -s
-    run ./execute_unix_benchmarks.sh -s
+    docker exec $CONTAINER_NAME /bin/bash -c "cd /pash && git pull"
+    run ./execute_eurosys_one_liners.sh -m
+    run ./execute_unix_benchmarks.sh -m
 
     ## Uncomment when ready to deal with large inputs.
     # run execute_baseline_sort.sh

--- a/scripts/remote/workers/run-perf.sh
+++ b/scripts/remote/workers/run-perf.sh
@@ -19,11 +19,11 @@ docker run -itd --name pash-perf pash /bin/bash
 trap 'cleanup' EXIT
 trap 'echo "<<fail>>"' ERR
 
-if [ -f lock ]; then
+if [ -d lock ]; then
     echo "Busy on existing job."
 else
-    touch lock
-    trap 'rm lock' EXIT
+    mkdir lock
+    trap 'rm -r lock' EXIT
 
     docker exec $CONTAINER_NAME /bin/bash -c "cd /pash && git pull"
     run ./execute_eurosys_one_liners.sh -m


### PR DESCRIPTION
This revision adds Unix50 and EuroSys one liner performance tests, using `-m`.

As of this writing, `memstar.ndr.md` is now configured to use the `workers/run-perf.sh` script, and `ci.pash.ndr.md` are now listening on port 2048 to manage `memstar.ndr.md`. Go ahead and run `curl ci.pash.ndr.md:2048/stdout` to see where the tests are right now. :)

If you wish to run this yourself, check the README in `scripts/remote`.

Notes:

* @angelhof: The Dockerfile has been updated to declare a locale, fixing #106. I ended up needing to do this to get past more and more Python errors when running scripts. Since we discussed it before, can you help me verify that this will not negatively impact artifacts?
* I updated all worker scripts to use empty directories for locks, since `mkdir` is atomic.
* The correctness test configuration has been updated to use less code, since the performance test controller needed to share some functionality.
* @nvasilakis: Despite what we discussed, I ended up downloading the entire results directory. It turned out to be pretty fast (< 1s) for me, and since it's using `rsync` I trust that the controller will download only incremental changes from then on. Let me know if this is okay with you.