### PR TITLE
fix more hardcoded paths to /bin/bash -> /usr/bin/env bash

### DIFF
--- a/compiler/pash.py
+++ b/compiler/pash.py
@@ -89,7 +89,7 @@ def preprocess(ast_objects, config):
     return preprocessed_asts
 
 def execute_script(compiled_script_filename):
-    exec_obj = subprocess.run(["/bin/bash", compiled_script_filename])
+    exec_obj = subprocess.run(["/usr/bin/env", "bash" ,compiled_script_filename])
     ## Return the exit code of the executed script
     exit(exec_obj.returncode)
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Ensure that the script fails if something failed
 set -e


### PR DESCRIPTION
Here are a couple of paths that needed to be fixed to run the basic pash examples.

Grepping around I noticed lots of others.

Maybe it'd be good to migrate them over to `!#/usr/bin/env bash` too. 