### PR TITLE
Install bsd utils for col

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,13 +45,13 @@ if [ "$prepare_sudo_install_flag" -eq 1 ]; then
     echo "|-- running apt update..."
     sudo apt-get update &> $LOG_DIR/apt_update.log
     echo "|-- running apt install..."
-    sudo apt-get install -y libtool m4 automake opam pkg-config libffi-dev python3 python3-pip wamerican-insane bc &> $LOG_DIR/apt_install.log
+    sudo apt-get install -y libtool m4 automake opam pkg-config libffi-dev python3 python3-pip wamerican-insane bc bsdmainutils &> $LOG_DIR/apt_install.log
     yes | opam init &> $LOG_DIR/opam_init.log
     # opam update
 else
-    echo "Requires libtool, m4, automake, opam, pkg-config, libffi-dev, python3, pip for python3, a dictionary, bc"
+    echo "Requires libtool, m4, automake, opam, pkg-config, libffi-dev, python3, pip for python3, a dictionary, bc, bsdmainutils"
     echo "Ensure that you have them by running:"
-    echo "  sudo apt install libtool m4 automake opam pkg-config libffi-dev python3 python3-pip wamerican-insane bc"
+    echo "  sudo apt install libtool m4 automake opam pkg-config libffi-dev python3 python3-pip wamerican-insane bc bsdmainutils"
     echo "  opam init"
     echo -n "Press 'y' if you have these dependencies installed. "
     while : ; do


### PR DESCRIPTION
This PR installs bsd utils for the `col` command. It is not yet ready to merge since we have to make sure that bsd utils do not replace coreutils.

Tests do pass though.

@nvasilakis how can we check that this is indeed the case?