### PR TITLE
Add with-ec2.sh

### DIFF
--- a/scripts/with-ec2.sh
+++ b/scripts/with-ec2.sh
@@ -1,0 +1,38 @@
+#! /bin/bash
+
+# Runs a command on the host within the lifespan of an EC2 instance.
+# Uses AWS CLI v2
+
+get-instance-ip() {
+    aws ec2 describe-instances \
+        --instance-ids "$1" \
+        --query 'Reservations[0].Instances[0].PublicIpAddress' \
+        --output text
+}
+
+# This is necessary because a public IP might not be
+# available immediately after the instance starts.
+wait-for-instance-ip() {
+    local variant="$(get-instance-ip "$1")";
+
+    if [[ "$variant" =~ [0-9] ]]; then
+        echo "$variant";
+    else
+        sleep 3;
+        wait-for-instance-ip "$1"
+    fi
+}
+
+call-with-active-ec2() {
+    set -e
+    local instance_id="$1"
+    aws ec2 start-instances --instance-ids "$instance_id"
+    local ip=$(wait-for-instance-ip "$instance_id");
+    echo "$ip"
+    trap "aws ec2 stop-instances --instance-ids $instance_id" EXIT
+    ${@:2} "$ip"
+}
+
+# First expression detects if script is being sourced.
+# https://stackoverflow.com/a/28776166
+(return 0 2>/dev/null) || call-with-active-ec2 "$@"


### PR DESCRIPTION
This script uses the AWS CLI (v2) to 

1. Start an EC2 instance by ID
2. Run a command with the public IP as an argument
3. Stops the instance on exit.

The given command runs on the host so that you can
script interactions between the host and instance. Using
instance IDs allows you to avoid needing to remember an
IP or public domain name (which can also change!).

To run a command on the EC2 host, you can make a script that
accepts the IP argument. Given the following script...

```
#! /bin/bash
# ps.sh
ssh -i ~/.ssh/aws.pem "ec2-user@$1" ps aux
```

...this command will show processes on the remote host.

```
with-ec2.sh i-0c8dabedc19aed710 ./ps.sh
```

(This assumes the OpenSSH server is listening at the time the public IP is available!
If this is not acceptable, then make `ps.sh` retry.)