### PR TITLE
Add make-ec2.sh and suggest-ec2.sh

### DIFF
--- a/scripts/aws/ec2/make-ec2.sh
+++ b/scripts/aws/ec2/make-ec2.sh
@@ -1,0 +1,20 @@
+#! /bin/bash
+
+# Pair with ./suggest-ec2.sh
+
+main() {
+    set -x
+    aws ec2 run-instances \
+        --output text \
+        --query "Instances[0].InstanceId" \
+        --image-id "$PASH_AWS_EC2_AMI" \
+        --instance-type "$PASH_AWS_EC2_INSTANCE_TYPE" \
+        --key-name "$PASH_AWS_EC2_KEY_NAME" \
+        --security-group-ids "$PASH_AWS_EC2_SECURITY_GROUP" \
+        --monitoring "Enabled=false" \
+        --subnet-id "$PASH_AWS_EC2_SUBNET" \
+        --query 'Instances[0].InstanceId' \
+        --output text
+}
+
+main

--- a/scripts/aws/ec2/make-ec2.sh
+++ b/scripts/aws/ec2/make-ec2.sh
@@ -14,6 +14,7 @@ main() {
         --monitoring "Enabled=false" \
         --subnet-id "$PASH_AWS_EC2_SUBNET" \
         --query 'Instances[0].InstanceId' \
+        --block-device-mappings "DeviceName=/dev/sda1,Ebs={VolumeSize=$PASH_AWS_EC2_DISK_SIZE_GB}" \
         --output text
 }
 

--- a/scripts/aws/ec2/suggest-ec2.sh
+++ b/scripts/aws/ec2/suggest-ec2.sh
@@ -13,6 +13,7 @@ main() {
     echo "export PASH_AWS_EC2_KEY_NAME='$key_name';";
     echo "export PASH_AWS_EC2_SUBNET='$subnet';";
     echo "export PASH_AWS_EC2_SECURITY_GROUP='$sg';";
+    echo "export PASH_AWS_EC2_DISK_SIZE_GB='10';";
 }
 
 main

--- a/scripts/aws/ec2/suggest-ec2.sh
+++ b/scripts/aws/ec2/suggest-ec2.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Suggests envvars for use in ./make-ec2-instance.sh
+
+main() {
+    local vpc_id="$(aws ec2 describe-vpcs --output text --query 'Vpcs[0].VpcId')";
+    local key_name="$(aws ec2 describe-key-pairs --output text --query 'KeyPairs[0].KeyName')";
+    local subnet="$(aws ec2 describe-subnets --output text --query 'Subnets[0].SubnetId' --filter Name=vpc-id,Values=$vpc_id)";
+    local sg="$(aws ec2 describe-security-groups --output text --filter Name=vpc-id,Values=$vpc_id --query 'SecurityGroups[0].GroupId')";
+
+    echo "export PASH_AWS_EC2_AMI='ami-0d739ceed1874f156';";
+    echo "export PASH_AWS_EC2_INSTANCE_TYPE='t2.micro';";
+    echo "export PASH_AWS_EC2_VPC_ID='$vpc_id';";
+    echo "export PASH_AWS_EC2_KEY_NAME='$key_name';";
+    echo "export PASH_AWS_EC2_SUBNET='$subnet';";
+    echo "export PASH_AWS_EC2_SECURITY_GROUP='$sg';";
+}
+
+main

--- a/scripts/aws/ec2/suggest-ec2.sh
+++ b/scripts/aws/ec2/suggest-ec2.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Suggests envvars for use in ./make-ec2-instance.sh
+# Suggests envvars for use in ./make-ec2.sh
 
 main() {
     local vpc_id="$(aws ec2 describe-vpcs --output text --query 'Vpcs[0].VpcId')";


### PR DESCRIPTION
Added script for creating EC2 instances. `make-ec2.sh` takes no arguments since it uses envvars.

Due to the complexity in the AWS CLI, I included another script called `suggest-ec2.sh`.
It queries your AWS account for data and prints shell code that you can `source` to configure
`make-ec2.sh`.

This gives you a moment to review/adjust variables before creating an instance.

```
./suggest-ec2.sh > env.sh
$EDITOR env.sh
. env.sh
./make-ec2.sh
```

This also allows you to create profiles. Just `source` the one you want.

```
cp env.sh itty-bitty-server.sh
cp env.sh typical-server.sh
cp env.sh big-expensive-monster.sh
$EDITOR ...
```