### PR TITLE
Fix on pash-c implementation

### DIFF
--- a/compiler/pash.py
+++ b/compiler/pash.py
@@ -17,20 +17,7 @@ import shutil
 def main():
     preprocessing_start_time = datetime.now()
     ## Parse arguments
-    args = parse_args()
-    config.pash_args = args
-
-    ## Initialize the log file
-    config.init_log_file()
-    if not config.config:
-        config.load_config(args.config_path)
-
-    ## Make a directory for temporary files
-    config.PASH_TMP_PREFIX = tempfile.mkdtemp(prefix="pash_")
-    if args.command:
-        with open(config.config['runtime']['immediate'], 'w') as f:
-            f.write(args.command)
-        args.input = f.name
+    args = parse_args();
 
     ## 1. Execute the POSIX shell parser that returns the AST in JSON
     input_script_path = args.input
@@ -69,20 +56,38 @@ def parse_args():
     if 'PASH_FROM_SH' in os.environ:
         prog_name = os.environ['PASH_FROM_SH']
     parser = argparse.ArgumentParser(prog_name)
-    group = parser.add_mutually_exclusive_group(required=True)
-
-    group.add_argument("input", nargs='?', help="the script to be compiled and executed")
+    # group = parser.add_mutually_exclusive_group(required=True)
+    # group.add_argument("input", nargs='?', help="the script to be compiled and executed")
+    parser.add_argument("input", nargs='?', help="the script to be compiled and executed")
     parser.add_argument("--preprocess_only",
                         help="only preprocess the input script and not execute it",
                         action="store_true")
     parser.add_argument("--output_preprocessed",
                         help=" output the preprocessed script",
                         action="store_true")
-    group.add_argument("-c", "--command",
+    parser.add_argument("-c", "--command",
                         help="Evaluate the following as a script, rather than a file",
                         default="")
     config.add_common_arguments(parser)
     args = parser.parse_args()
+    config.pash_args = args;
+
+    ## Initialize the log file
+    config.init_log_file()
+    if not config.config:
+        config.load_config(args.config_path)
+
+    ## Make a directory for temporary files
+    config.PASH_TMP_PREFIX = tempfile.mkdtemp(prefix="pash_")
+    if args.command:
+        with open(config.config['runtime']['immediate'], 'w') as f:
+            f.write(args.command)
+            args.input = f.name
+
+    if (args.input == None):
+        parser.print_usage()
+        exit();
+
     return args
 
 def preprocess(ast_objects, config):

--- a/compiler/pash.py
+++ b/compiler/pash.py
@@ -30,7 +30,7 @@ def main():
     if args.command:
         with open(config.config['runtime']['immediate'], 'w') as f:
             f.write(args.command)
-        args.input = './.tmp_script.sh'
+        args.input = f.name
 
     ## 1. Execute the POSIX shell parser that returns the AST in JSON
     input_script_path = args.input
@@ -61,7 +61,7 @@ def main():
 
     ## 5. Execute the preprocessed version of the input script
     if(not args.preprocess_only):
-        execute_script(fname, args.debug)
+        execute_script(fname, args.debug, args.command)
 
 
 def parse_args():
@@ -69,14 +69,16 @@ def parse_args():
     if 'PASH_FROM_SH' in os.environ:
         prog_name = os.environ['PASH_FROM_SH']
     parser = argparse.ArgumentParser(prog_name)
-    parser.add_argument("input", nargs='?', help="the script to be compiled and executed")
+    group = parser.add_mutually_exclusive_group(required=True)
+
+    group.add_argument("input", nargs='?', help="the script to be compiled and executed")
     parser.add_argument("--preprocess_only",
                         help="only preprocess the input script and not execute it",
                         action="store_true")
     parser.add_argument("--output_preprocessed",
                         help=" output the preprocessed script",
                         action="store_true")
-    parser.add_argument("-c", "--command",
+    group.add_argument("-c", "--command",
                         help="Evaluate the following as a script, rather than a file",
                         default="")
     config.add_common_arguments(parser)
@@ -94,14 +96,14 @@ def preprocess(ast_objects, config):
 
     return preprocessed_asts
 
-def execute_script(compiled_script_filename, debug_level):
+def execute_script(compiled_script_filename, debug_level, command):
     new_env = os.environ.copy()
     new_env["PASH_TMP_PREFIX"] = config.PASH_TMP_PREFIX
     exec_obj = subprocess.run(["/usr/bin/env", "bash" ,compiled_script_filename], env=new_env)
     ## Delete the temp directory when not debugging
     if(debug_level == 0):
         shutil.rmtree(config.PASH_TMP_PREFIX)
-    if args.command:
+    if command:
         os.remove(config.config['runtime']['immediate'])
     ## Return the exit code of the executed script
     exit(exec_obj.returncode)

--- a/compiler/pash.py
+++ b/compiler/pash.py
@@ -56,8 +56,6 @@ def parse_args():
     if 'PASH_FROM_SH' in os.environ:
         prog_name = os.environ['PASH_FROM_SH']
     parser = argparse.ArgumentParser(prog_name)
-    # group = parser.add_mutually_exclusive_group(required=True)
-    # group.add_argument("input", nargs='?', help="the script to be compiled and executed")
     parser.add_argument("input", nargs='?', help="the script to be compiled and executed")
     parser.add_argument("--preprocess_only",
                         help="only preprocess the input script and not execute it",
@@ -70,7 +68,7 @@ def parse_args():
                         default="")
     config.add_common_arguments(parser)
     args = parser.parse_args()
-    config.pash_args = args;
+    config.pash_args = args
 
     ## Initialize the log file
     config.init_log_file()
@@ -86,7 +84,7 @@ def parse_args():
 
     if (args.input == None):
         parser.print_usage()
-        exit();
+        exit()
 
     return args
 


### PR DESCRIPTION
The current implementation uses a fixed name (pash_immediate_command.sh) to write the input for the command to execute. This might be a problem when executing multiple 'pash -c' commands on the same path as all of them will write on the same file? 