### PR TITLE
Quick abort

### DIFF
--- a/compiler/pash_runtime.sh
+++ b/compiler/pash_runtime.sh
@@ -220,6 +220,7 @@ if [ "$pash_speculation_flag" -eq 1 ]; then
     ## Count the execution time
     pash_exec_time_start=$(date +"%s%N")
     source "$RUNTIME_DIR/pash_runtime_quick_abort.sh"
+    pash_runtime_final_status=$?
 else
     pash_redir_all_output python3 "$RUNTIME_DIR/pash_runtime.py" ${pash_compiled_script_file} --var_file "${pash_runtime_shell_variables_file}" "${@:2}"
     pash_runtime_return_code=$?

--- a/compiler/pash_runtime_quick_abort.sh
+++ b/compiler/pash_runtime_quick_abort.sh
@@ -125,7 +125,7 @@ if [ "$pash_execute_flag" -eq 1 ]; then
 
         ## We only want to run the parallel if the compiler succeeded.
         ## TODO: Enable that
-        if false && [ "$pash_runtime_return_code" -eq 0 ]; then
+        if [ "$pash_runtime_return_code" -eq 0 ]; then
 
             ## TODO: We really need to kill the sequential (so that it stops writing to other outputs).
             ##       Actually we need to call it with reroute to dump its stdin to /dev/null and kill it.

--- a/compiler/pash_runtime_quick_abort.sh
+++ b/compiler/pash_runtime_quick_abort.sh
@@ -168,15 +168,17 @@ if [ "$pash_execute_flag" -eq 1 ]; then
         pash_redir_output echo "(QAbort) Sequential was done first with return code: $pash_runtime_final_status"
 
         ## (1) Redirect the seq output to stdout
-        cat "$pash_seq_eager2_output"
-        pash_redir_output echo "STDOUT cat pid: $!"
+        cat "$pash_seq_eager2_output" &
+        final_cat_pid=$!
+        pash_redir_output echo "(QAbort) STDOUT cat pid: $final_cat_pid"
 
-        # ## If this fails (meaning that compilation is done) we do not care
-        # ## TODO: Do we actually need to kill compiler
-        # kill -n 9 "$pash_compiler_pid" 2> /dev/null
-        # wait -n "$pash_compiler_pid"  2> /dev/null
-        # pash_runtime_final_status=$completed_pid_status
-        # pash_redir_output echo "(QAbort) Still alive: $(still_alive)"
+        ## If this fails (meaning that compilation is done) we do not care
+        ## TODO: Do we actually need to kill compiler
+        kill -9 "$pash_compiler_pid" 2> /dev/null
+        wait "$pash_compiler_pid"  2> /dev/null
+        pash_redir_output echo "(QAbort) Still alive: $(still_alive)"
+
+        wait "$final_cat_pid"
     fi
     
     ## Return the exit code

--- a/compiler/pash_runtime_quick_abort.sh
+++ b/compiler/pash_runtime_quick_abort.sh
@@ -88,13 +88,22 @@ if [ "$pash_execute_flag" -eq 1 ]; then
     pash_seq_pid=$!
     pash_redir_output echo "Sequential pid: $pash_seq_pid"
 
+    ## (E) The sequential output eager
+    pash_seq_eager2_output="$($RUNTIME_DIR/pash_ptempfile_name.sh)"
+    mkfifo "$pash_seq_eager2_output"
+    pash_seq_eager2_file="$($RUNTIME_DIR/pash_ptempfile_name.sh)"
+    "$RUNTIME_DIR/../runtime/eager" "$pash_seq_output" "$pash_seq_eager2_output" "$pash_seq_eager2_file" &
+
     ## (F) Second eager
     cat "$pash_tee_stdout2" > /dev/null &
 
-    cat "$pash_seq_output"
-
+    ## Once this is done, we can redirect the output
     wait $pash_seq_pid
     pash_seq_status=$?
+
+    ## (1) Redirect the seq output to stdout
+    cat "$pash_seq_eager2_output"
+
     (exit "$pash_seq_status")
 
 

--- a/compiler/pash_runtime_quick_abort.sh
+++ b/compiler/pash_runtime_quick_abort.sh
@@ -114,6 +114,7 @@ if [ "$pash_execute_flag" -eq 1 ]; then
         ## Wait for either of the two to complete
         wait -n "$pash_seq_pid" "$pash_compiler_pid"
         completed_pid_status=$?
+        pash_redir_output echo "(QAbort) Process exited with return code: $completed_pid_status"
         alive_pids=$(still_alive)
         pash_redir_output echo "(QAbort) Still alive: $alive_pids"
     done
@@ -164,18 +165,18 @@ if [ "$pash_execute_flag" -eq 1 ]; then
         fi
     else
         pash_runtime_final_status=$completed_pid_status
-        pash_redir_output echo "(QAbort) Sequential was done first!"
+        pash_redir_output echo "(QAbort) Sequential was done first with return code: $pash_runtime_final_status"
 
         ## (1) Redirect the seq output to stdout
         cat "$pash_seq_eager2_output"
         pash_redir_output echo "STDOUT cat pid: $!"
 
-        ## If this fails (meaning that compilation is done) we do not care
-        ## TODO: Do we actually need to kill compiler
+        # ## If this fails (meaning that compilation is done) we do not care
+        # ## TODO: Do we actually need to kill compiler
         # kill -n 9 "$pash_compiler_pid" 2> /dev/null
         # wait -n "$pash_compiler_pid"  2> /dev/null
         # pash_runtime_final_status=$completed_pid_status
-        # pash_redir_output echo "Still alive: $(still_alive)"
+        # pash_redir_output echo "(QAbort) Still alive: $(still_alive)"
     fi
     
     ## Return the exit code

--- a/compiler/pash_runtime_quick_abort.sh
+++ b/compiler/pash_runtime_quick_abort.sh
@@ -3,72 +3,6 @@
 ## File directory
 RUNTIME_DIR=$(dirname "${BASH_SOURCE[0]}")
 
-## Current plan: Optimistic sequential execution with eager in stdin stdout. 
-## If the compiler succeeds in compiling (and improving) the script and the following two constraints hold:
-##  (1) The outputs of the DFG are not appended
-##  (2) All input and output files are simple files in the file system (no device files, fifos, etc)
-## then we empty the output files, stop the original script, and execute the parallel script.
-## (Note that we have to reroute what was in the stdin eager buffer to the parallel script.)
-##
-## Else if the original script finished execution before compilation succeeds, or if compilation fails:
-## - We pipe stdout eager to stdout
-## - We let everything finish.
-
-## Assumptions/Constraints:
-##
-## For now we can assume that constraints (1) and (2) hold.
-##
-## TODO: A first TODO would be to check them in the compilation process
-##
-## TODO: An alternative TODO would be to let preprocessing give us information about them, allowing us to 
-##       have a finer tuned execution plan depending on this information. For example, if we see that script
-##       has append to some file we can be carefull and buffer its output using eager.
-
-## Implementation proposal: Use a signal trap
-##
-## ISSUE: It seems that bash waits to handle a trap only after a command that it executes finished execution.
-##        This means that we can't reliably use source and signal traps.
-##
-## POSSIBLE SOLUTION: 
-##        At the moment we use source for two reasons.
-##          1. To see changes in variables in the parent shell.
-##          2. To see local variables in the sourced shell.
-##        To address the above issue, we could avoid using source,
-##        and actually run the original script in a subshell that first reads its parents
-##        local variables and then exports back the variables.
-
-## NOTE: The intuition about why quick-abort works is that if the compilation succeeds, then the
-##       script is a DFG, meaning that we know exactly how it affects its environment after completing.
-##       Therefore, we can go back and stop the already running script without risking unsafe behavior.
-
-## TODO: We need to *at least* capture the stdout and stderr of the executed bash script 
-##       if we ever want to have a change of running a compiled version in its place.
-##       In order to do that, we can pipe its stdout and stderr to an eager command (so that it doesn't get lost)
-##       and if we actually need it, we can pipe from the output of the eager command to stdout and stderr.
-##
-##       If it ends out that we don't need it we can just kill the command and dump its
-##       outputs to /dev/null.
-
-## TODO: If the output of the DFG is more than just stdout, then we actually need to first delete
-##       what the outputs (since they will be rewritten from the DFG).
-
-## ISSUE: What about if the DFG appends(!) to its output (instead of just writing). Then
-##        we can't handle it correctly.
-
-## ISSUE: We can't actually `source` the execution of the sequential if we later want to kill it.
-##
-## POSSIBLE SOLUTION: 
-##        Maybe we can develop a signal handler in the PaSh runtime that receives a signal and starts executing the parallel version.
-##        Then we can fork of a process that runs the python `pash_runtime` and if it is completed, it can send the signal to 
-##        current shell.
-## 
-## TODO: If we choose to follow this solution we have to make sure that there is no race condition.
-
-## TODO: We also want to avoid executing the compiled script if it doesn't contain any improvement.
-
-## Execute both the sequential and the compiler in parallel and only run the parallel
-## compiled script if the compiler finished before the sequential.
-
 still_alive()
 {
     jobs -p | tr '\n' ' '
@@ -89,112 +23,179 @@ function list_include_item {
 }
 
 
+## Solution Schematic:
+##
+##  (A)      (B)      (C)       (D)                (E)
+## stdin --- tee --- eager --- reroute seq.sh --- eager --- OUT_SEQ
+##            \      (F)
+##             \--- eager --- PAR_IN
+##
+## (1) If compiler fails, or sequential is done executing:
+##     - cat OUT_SEQ > stdout
+##
+## (2) If compiler succeeds:
+##     - USR1 to reroute so that it redirects to /dev/null
+##     - PAR_IN redirect to par stdin.
+##
+## Simplifying assumptions:
+## - Not worrying about stderr
+## - Not worrying about other inputs at the moment (assuming they are files if compiler succeeds)
+## - Not worrying about other outputs 
+##   + assuming that the parallel implementation will overwrite them
+##   + Assuming that the DFG outputs are not appended
+##
+## TODO: A first TODO would be to check them in the compilation process
+##
+## TODO: An alternative TODO would be to let preprocessing give us information about them, allowing us to 
+##       have a finer tuned execution plan depending on this information. For example, if we see that script
+##       has append to some file we can be carefull and buffer its output using eager.
+
+## NOTE: The intuition about why quick-abort works is that if the compilation succeeds, then the
+##       script is a DFG, meaning that we know exactly how it affects its environment after completing.
+##       Therefore, we can go back and stop the already running script without risking unsafe behavior.
+
+## TODO: We also want to avoid executing the compiled script if it doesn't contain any improvement.
+
 if [ "$pash_execute_flag" -eq 1 ]; then
-    ## Note: First solution does not contain eager in stdout, therefore not being interactive.
-    ## TODO: (Optimization) Fix the issue with eager in the output to make it interactive
-
-    ## TODO: Fix the issue with the input. We have to first redirect input through an eager
-    ##       so that it is saved and then redirected to the parallel one.
-
-    ## Before running the original script we need to redirect its input and output to 
-    ## eager and pipes.
-    pash_stdin_redir1="$($RUNTIME_DIR/pash_ptempfile_name.sh)"
-    pash_stdin_redir2="$($RUNTIME_DIR/pash_ptempfile_name.sh)"
-    # pash_stdout_redir1="$($RUNTIME_DIR/pash_ptempfile_name.sh)"
-    pash_stdout_redir2="$($RUNTIME_DIR/pash_ptempfile_name.sh)"
-    pash_stdin_eager_file="$($RUNTIME_DIR/pash_ptempfile_name.sh)"
-    pash_redir_output echo "eager intermediate file: $pash_stdin_eager_file"
-    # pash_stdout_eager_file="$($RUNTIME_DIR/pash_ptempfile_name.sh)"
-    mkfifo $pash_stdin_redir1 $pash_stdin_redir2
-    # mkfifo $pash_stdin_redir1 $pash_stdin_redir2 $pash_stdout_redir1 $pash_stdout_redir2
-
-
-    ## TODO: Find the eager directory correctly
-    "$RUNTIME_DIR/../evaluation/tools/eager" "$pash_stdin_redir1" "$pash_stdin_redir2" "$pash_stdin_eager_file" &
-    pash_redir_output echo "STDIN eager pid: $!"
-    # ../evaluation/tools/eager "$pash_stdout_redir1" "$pash_stdout_redir2" "$pash_stdout_eager_file" &
-    # pash_redir_output echo "STDOUT eager pid: $!"
+    # set -x
+    ## (A) Redirect stdin to `tee`
+    pash_tee_stdin="$($RUNTIME_DIR/pash_ptempfile_name.sh)"
+    mkfifo "$pash_tee_stdin"
     ## The redirections below are necessary to ensure that the background `cat` reads from stdin.
-    { cat > "$pash_stdin_redir1" <&3 3<&- & } 3<&0
-    pash_redir_output echo "STDIN cat pid: $!"
-    ## Note: We don't connect stdout_redir2 yet, since it has to be bufferred for correctness. 
+    { cat > "$pash_tee_stdin" <&3 3<&- & } 3<&0
 
-    ## Run the original script
-    # "$RUNTIME_DIR/pash_wrap_vars.sh" $pash_runtime_shell_variables_file $pash_output_variables_file ${pash_output_set_file} ${pash_sequential_script_file} > "$pash_stdout_redir1" < "$pash_stdin_redir2" &
-    "$RUNTIME_DIR/pash_wrap_vars.sh" $pash_runtime_shell_variables_file $pash_output_variables_file ${pash_output_set_file} ${pash_sequential_script_file} > "$pash_stdout_redir2" < "$pash_stdin_redir2" &
-    # "$RUNTIME_DIR/pash_wrap_vars.sh" $pash_runtime_shell_variables_file $pash_output_variables_file ${pash_output_set_file} ${pash_sequential_script_file} > "$pash_stdout_redir2" &
+    ## (B) A `tee` that duplicates input to both the sequential and parallel
+    pash_tee_stdout1="$($RUNTIME_DIR/pash_ptempfile_name.sh)"
+    pash_tee_stdout2="$($RUNTIME_DIR/pash_ptempfile_name.sh)"
+    mkfifo "$pash_tee_stdout1" "$pash_tee_stdout2"
+    tee "$pash_tee_stdout1" > "$pash_tee_stdout2" < "$pash_tee_stdin" &
+
+    ## (C) The sequential input eager
+    pash_seq_eager_output="$($RUNTIME_DIR/pash_ptempfile_name.sh)"
+    mkfifo "$pash_seq_eager_output"
+    pash_seq_eager_file="$($RUNTIME_DIR/pash_ptempfile_name.sh)"
+    "$RUNTIME_DIR/../runtime/eager" "$pash_tee_stdout1" "$pash_seq_eager_output" "$pash_seq_eager_file" &
+
+    ## (D) Sequential command
+    pash_seq_output="$($RUNTIME_DIR/pash_ptempfile_name.sh)"
+    mkfifo "$pash_seq_output"
+    "$RUNTIME_DIR/pash_wrap_vars.sh" \
+        $pash_runtime_shell_variables_file \
+        $pash_output_variables_file \
+        ${pash_output_set_file} \
+        ${pash_sequential_script_file} \
+        > "$pash_seq_output" < "$pash_seq_eager_output" &
     pash_seq_pid=$!
     pash_redir_output echo "Sequential pid: $pash_seq_pid"
 
-    ## Run the compiler
-    pash_redir_all_output python3 pash_runtime.py ${pash_compiled_script_file} --var_file "${pash_runtime_shell_variables_file}" "${@:2}" &
-    pash_compiler_pid=$!
-    pash_redir_output echo "Compiler pid: $pash_compiler_pid"
+    ## (F) Second eager
+    cat "$pash_tee_stdout2" > /dev/null &
+
+    cat "$pash_seq_output"
+
+    wait $pash_seq_pid
+    pash_seq_status=$?
+    (exit "$pash_seq_status")
+
+
+    # ## Before running the original script we need to redirect its input and output to 
+    # ## eager and pipes.
+    # pash_stdin_redir1="$($RUNTIME_DIR/pash_ptempfile_name.sh)"
+    # pash_stdin_redir2="$($RUNTIME_DIR/pash_ptempfile_name.sh)"
+    # # pash_stdout_redir1="$($RUNTIME_DIR/pash_ptempfile_name.sh)"
+    # pash_stdout_redir2="$($RUNTIME_DIR/pash_ptempfile_name.sh)"
+    # pash_stdin_eager_file="$($RUNTIME_DIR/pash_ptempfile_name.sh)"
+    # pash_redir_output echo "eager intermediate file: $pash_stdin_eager_file"
+    # # pash_stdout_eager_file="$($RUNTIME_DIR/pash_ptempfile_name.sh)"
+    # mkfifo $pash_stdin_redir1 $pash_stdin_redir2
+    # # mkfifo $pash_stdin_redir1 $pash_stdin_redir2 $pash_stdout_redir1 $pash_stdout_redir2
+
+
+    # ## TODO: Find the eager directory correctly
+    # "$RUNTIME_DIR/../evaluation/tools/eager" "$pash_stdin_redir1" "$pash_stdin_redir2" "$pash_stdin_eager_file" &
+    # pash_redir_output echo "STDIN eager pid: $!"
+    # # ../evaluation/tools/eager "$pash_stdout_redir1" "$pash_stdout_redir2" "$pash_stdout_eager_file" &
+    # # pash_redir_output echo "STDOUT eager pid: $!"
+    
+    # pash_redir_output echo "STDIN cat pid: $!"
+    # ## Note: We don't connect stdout_redir2 yet, since it has to be bufferred for correctness. 
+
+    # ## Run the original script
+    # # "$RUNTIME_DIR/pash_wrap_vars.sh" $pash_runtime_shell_variables_file $pash_output_variables_file ${pash_output_set_file} ${pash_sequential_script_file} > "$pash_stdout_redir1" < "$pash_stdin_redir2" &
+    # "$RUNTIME_DIR/pash_wrap_vars.sh" $pash_runtime_shell_variables_file $pash_output_variables_file ${pash_output_set_file} ${pash_sequential_script_file} > "$pash_stdout_redir2" < "$pash_stdin_redir2" &
+    # # "$RUNTIME_DIR/pash_wrap_vars.sh" $pash_runtime_shell_variables_file $pash_output_variables_file ${pash_output_set_file} ${pash_sequential_script_file} > "$pash_stdout_redir2" &
+    # pash_seq_pid=$!
+    # pash_redir_output echo "Sequential pid: $pash_seq_pid"
+
+    # ## Run the compiler
+    # pash_redir_all_output python3 pash_runtime.py ${pash_compiled_script_file} --var_file "${pash_runtime_shell_variables_file}" "${@:2}" &
+    # pash_compiler_pid=$!
+    # pash_redir_output echo "Compiler pid: $pash_compiler_pid"
 
     
-    ## Wait until one of the two (original script, or compiler) die
-    alive_pids=$(still_alive)
-    pash_redir_output echo "Still alive: $alive_pids"
-    while `list_include_item "$alive_pids" "$pash_seq_pid"` && `list_include_item "$alive_pids" "$pash_compiler_pid"` ; do
-        ## Wait for either of the two to complete
-        wait -n "$pash_seq_pid" "$pash_compiler_pid"
-        completed_pid_status=$?
-        alive_pids=$(still_alive)
-        pash_redir_output echo "Still alive: $alive_pids"
-    done
+    # ## Wait until one of the two (original script, or compiler) die
+    # alive_pids=$(still_alive)
+    # pash_redir_output echo "Still alive: $alive_pids"
+    # while `list_include_item "$alive_pids" "$pash_seq_pid"` && `list_include_item "$alive_pids" "$pash_compiler_pid"` ; do
+    #     ## Wait for either of the two to complete
+    #     wait -n "$pash_seq_pid" "$pash_compiler_pid"
+    #     completed_pid_status=$?
+    #     alive_pids=$(still_alive)
+    #     pash_redir_output echo "Still alive: $alive_pids"
+    # done
 
-    ## If the sequential is still alive we want to see if the compiler succeeded
-    if `list_include_item "$alive_pids" "$pash_seq_pid"` ; then
-    # if [ "$pash_seq_pid" -eq "$alive_pids" ]; then
-        pash_runtime_return_code=$completed_pid_status
-        pash_redir_output echo "Compilation was done first with return code: $pash_runtime_return_code"
+    # ## If the sequential is still alive we want to see if the compiler succeeded
+    # if `list_include_item "$alive_pids" "$pash_seq_pid"` ; then
+    # # if [ "$pash_seq_pid" -eq "$alive_pids" ]; then
+    #     pash_runtime_return_code=$completed_pid_status
+    #     pash_redir_output echo "Compilation was done first with return code: $pash_runtime_return_code"
 
-        ## We only want to run the parallel if the compiler succeeded.
-        if [ "$pash_runtime_return_code" -eq 0 ]; then
-            kill -n 9 "$pash_seq_pid" 2> /dev/null
-            kill_status=$?
-            wait "$pash_seq_pid" 2> /dev/null
-            pash_runtime_final_status=$?
-            pash_redir_output echo "Still alive: $(still_alive)"
+    #     ## We only want to run the parallel if the compiler succeeded.
+    #     if [ "$pash_runtime_return_code" -eq 0 ]; then
+    #         kill -n 9 "$pash_seq_pid" 2> /dev/null
+    #         kill_status=$?
+    #         wait "$pash_seq_pid" 2> /dev/null
+    #         pash_runtime_final_status=$?
+    #         pash_redir_output echo "Still alive: $(still_alive)"
 
-            ## If kill failed it means it was already completed, 
-            ## and therefore we do not need to run the parallel.
-            if [ "$kill_status" -eq 0 ]; then
-                pash_redir_output echo "Run parallel"
-                ## TODO: Find the outputs/inputs of the DFG and make sure that the outputs 
-                ##       are clean and normal files (and the inputs are normal files)
+    #         ## If kill failed it means it was already completed, 
+    #         ## and therefore we do not need to run the parallel.
+    #         if [ "$kill_status" -eq 0 ]; then
+    #             pash_redir_output echo "Run parallel"
+    #             ## TODO: Find the outputs/inputs of the DFG and make sure that the outputs 
+    #             ##       are clean and normal files (and the inputs are normal files)
 
-                ## TODO: Redirect stdin/stdout so that the parallel one gets them from the start
-                ##       and so that there are no duplicate entries in the stdout.
-                ## TODO: This seems like a non-trivial solution since it requires keeping stdin open, 
-                ##       while "restarting" the eager, making it send its output to a new pipe, and
-                ##       then first reading all from its intermediate file. 
-                "$RUNTIME_DIR/pash_wrap_vars.sh" $pash_runtime_shell_variables_file $pash_output_variables_file ${pash_output_set_file} ${pash_compiled_script_file}
-                pash_runtime_final_status=$?
-            fi
-        else
-            ## If the compiler failed we just wait until the sequential is done.
+    #             ## TODO: Redirect stdin/stdout so that the parallel one gets them from the start
+    #             ##       and so that there are no duplicate entries in the stdout.
+    #             ## TODO: This seems like a non-trivial solution since it requires keeping stdin open, 
+    #             ##       while "restarting" the eager, making it send its output to a new pipe, and
+    #             ##       then first reading all from its intermediate file. 
+    #             "$RUNTIME_DIR/pash_wrap_vars.sh" $pash_runtime_shell_variables_file $pash_output_variables_file ${pash_output_set_file} ${pash_compiled_script_file}
+    #             pash_runtime_final_status=$?
+    #         fi
+    #     else
+    #         ## If the compiler failed we just wait until the sequential is done.
 
-            wait -n "$pash_seq_pid"
+    #         wait -n "$pash_seq_pid"
 
-            ## TODO: Redirect eagers to stdin + stdout
-            cat "$pash_stdout_redir2" &
-            pash_redir_output echo "STDOUT cat pid: $!"
-            pash_redir_output echo "Still alive: $(still_alive)"
+    #         ## TODO: Redirect eagers to stdin + stdout
+    #         cat "$pash_stdout_redir2" &
+    #         pash_redir_output echo "STDOUT cat pid: $!"
+    #         pash_redir_output echo "Still alive: $(still_alive)"
 
-            pash_runtime_final_status=$?
-        fi
-    else
-        pash_redir_output echo "Sequential was done first!"
+    #         pash_runtime_final_status=$?
+    #     fi
+    # else
+    #     pash_redir_output echo "Sequential was done first!"
 
-        ## TODO: Redirect eagers to stdin + stdout
-        cat "$pash_stdout_redir2" &
-        pash_redir_output echo "STDOUT cat pid: $!"
+    #     ## TODO: Redirect eagers to stdin + stdout
+    #     cat "$pash_stdout_redir2" &
+    #     pash_redir_output echo "STDOUT cat pid: $!"
 
-        ## If this fails (meaning that compilation is done) we do not care
-        kill -n 9 "$pash_compiler_pid" 2> /dev/null
-        wait -n "$pash_compiler_pid"  2> /dev/null
-        pash_runtime_final_status=$completed_pid_status
-        pash_redir_output echo "Still alive: $(still_alive)"
-    fi
+    #     ## If this fails (meaning that compilation is done) we do not care
+    #     kill -n 9 "$pash_compiler_pid" 2> /dev/null
+    #     wait -n "$pash_compiler_pid"  2> /dev/null
+    #     pash_runtime_final_status=$completed_pid_status
+    #     pash_redir_output echo "Still alive: $(still_alive)"
+    # fi
 fi

--- a/compiler/test_evaluation_scripts.sh
+++ b/compiler/test_evaluation_scripts.sh
@@ -30,6 +30,7 @@ configurations=(
     "--r_split"
     "--dgsh_tee"
     "--r_split --dgsh_tee"
+    # "--speculation quick_abort"
 )
 
 ## Tests where the compiler will not always succeed (e.g. because they have mkfifo)
@@ -126,8 +127,10 @@ execute_tests() {
             echo "|-- Has input file: $stdin_redir"
         fi
 
-        echo "|-- Executing the script with bash..."
-        cat $stdin_redir | { time /bin/bash "$script_to_execute" > $seq_output ; } 2> "${seq_time}"
+        echo -n "|-- Executing the script with bash..."
+        { time /bin/bash "$script_to_execute" > $seq_output ; } \
+            < "$stdin_redir" 2> "${seq_time}"
+        echo "   exited with $?"
 
         for conf in "${configurations[@]}"; do
             for n_in in "${n_inputs[@]}"; do

--- a/evaluation/tests/grep.sh
+++ b/evaluation/tests/grep.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-cat $IN | grep '[a-zA-Z0-9]\+@[a-zA-Z0-9]\+\.[a-z]\{2,\}'
+cat $IN | grep 'the'


### PR DESCRIPTION
Mostly working, however if the sequential is done first, the compiler's log is produced in a delayed fashion, having a little clunky behavior when running in an interactive shell with `-d 1` and without a log_file.

It is not thoroughly tested yet, but we should merge as a first step.