### PR TITLE
Added bash -c for every r_wrap

### DIFF
--- a/annotations/custom_tr.json
+++ b/annotations/custom_tr.json
@@ -1,0 +1,12 @@
+{
+    "command": "custom_tr",
+    "cases":
+    [
+        {
+            "predicate": "default",
+            "class": "stateless",
+            "inputs": ["stdin"],
+            "outputs": ["stdout"]
+        }
+    ]
+}

--- a/compiler/definitions/ir/nodes/r_wrap.py
+++ b/compiler/definitions/ir/nodes/r_wrap.py
@@ -28,8 +28,11 @@ def wrap_node(node):
 
     ## TODO: All arguments must be options, otherwise there must be
     ##       special handling in the wrap node2ast code. 
-    old_options_transposed = [(i+1, opt) for i, opt in node.com_options]
-    options = [(0, node.com_name)] + old_options_transposed
+    old_options_strs = [str(opt) for i, opt in node.com_options]
+    wrapped_command = " ".join([str(node.com_name)] + old_options_strs)
+    wrapped_command_arg = [(1, Arg(string_to_argument(f"\'{wrapped_command}\'")))]
+    bash_command_arg = [(0, Arg(string_to_argument("bash -c")))]
+    options = bash_command_arg +  wrapped_command_arg
 
     ## TODO: It is not clear if it is safe to just pass redirections and assignments down the line as is
     redirs = node.com_redirs

--- a/compiler/test_evaluation_scripts.sh
+++ b/compiler/test_evaluation_scripts.sh
@@ -41,6 +41,7 @@ script_microbenchmarks=(
     comm-par-test        # Small comm test to ensure non-parallelizability
     comm-par-test2       # Small comm test with input redirection and hyphen
     tee_web_index_bug    # Tests a tee bug from web index
+    fun-def              # Tests whether PaSh can handle a simple function definition
 )
 
 pipeline_microbenchmarks=(
@@ -60,7 +61,6 @@ pipeline_microbenchmarks=(
     minimal_grep_stdin   # Tests whether PaSh can handle a script that reads from stdin
     micro_10             # A small version of the pipeline above for debugging.
     sed-test             # Tests all sed occurences in our evaluation to make sure that they work
-    fun-def              # Tests whether PaSh can handle a simple function definition
     tr-test              # Tests all possible behaviors of tr that exist in our evaluation
     grep-test            # Tests some interesting grep invocations
     # # # micro_1000           # Not being run anymore, as it is very slow. Tests whether the compiler is fast enough. It is a huge pipeline without any computation.

--- a/evaluation/tests/fun-def.sh
+++ b/evaluation/tests/fun-def.sh
@@ -4,6 +4,12 @@ custom_sort() {
     sort $@
 }
 
+custom_tr() {
+    tr A-Z a-z
+}
+
+export -f custom_tr
+
 FILES="../evaluation/tests/input/1M.txt ../evaluation/tests/input/1M.txt"
 
-cat $FILES | tr A-Z a-z | custom_sort
+cat $FILES | custom_tr | custom_sort


### PR DESCRIPTION
This is a fix to allow r_wrap to execute bash functions. Functions still need to be exported for r_wrap to be able to use them. A better long-term solution would be to only add bash -c when calling r_wrap with a function.