### PR TITLE
Make sure that tests run without experimental flags

### DIFF
--- a/annotations/iconv.json
+++ b/annotations/iconv.json
@@ -4,7 +4,7 @@
     [
         {
             "predicate": "default",
-            "class": "stateless",
+            "class": "pure",
             "inputs": ["stdin"],
             "outputs": ["stdout"]
         }

--- a/compiler/test_evaluation_scripts.sh
+++ b/compiler/test_evaluation_scripts.sh
@@ -5,6 +5,21 @@ export PASH_TOP=${PASH_TOP:-$(git rev-parse --show-toplevel --show-superproject-
 export DEBUG=0
 # export DEBUG=1 # Uncomment to print pash output
 
+## Determines whether the experimental pash flags will be tested. 
+## By default they are not.
+export EXPERIMENTAL=0
+
+for item in $@
+do
+    if [ "--debug" == "$item" ] || [ "-d" == "$item" ]; then
+        export DEBUG=1
+    fi
+
+    if [ "--experimental" == "$item" ]; then
+        export EXPERIMENTAL=1
+    fi
+done
+
 microbenchmarks_dir="${PASH_TOP}/evaluation/tests/"
 intermediary_dir="${PASH_TOP}/evaluation/tests/test_intermediary/"
 test_results_dir="${PASH_TOP}/evaluation/tests/results/"
@@ -25,13 +40,21 @@ n_inputs=(
     8
 )
 
-configurations=(
-    # "" # Commenting this out since the tests take a lot of time to finish
-    "--r_split"
-    "--dgsh_tee"
-    "--r_split --dgsh_tee"
-    # "--speculation quick_abort"
-)
+
+if [ "$EXPERIMENTAL" -eq 1 ]; then
+    configurations=(
+        # "" # Commenting this out since the tests take a lot of time to finish
+        "--r_split"
+        "--dgsh_tee"
+        "--r_split --dgsh_tee"
+        # "--speculation quick_abort"
+    )
+else
+    configurations=(
+        ""
+    )
+fi
+
 
 ## Tests where the compiler will not always succeed (e.g. because they have mkfifo)
 script_microbenchmarks=(

--- a/evaluation/benchmarks/run.par.sh
+++ b/evaluation/benchmarks/run.par.sh
@@ -58,7 +58,7 @@ oneliners_pash(){
     par_outputs_file="${outputs_dir}/${script}.${par_outputs_suffix}"
     pash_log="${pash_logs_dir}/${script}.pash.log"
 
-    echo "${padded_script}" $({ time "$PASH_TOP/pa.sh" --r_split --dgsh_tee -d 1 -w "${width}" --log_file "${pash_log}" ${script}.sh > "$par_outputs_file"; } 2>&1) | tee -a "$par_times_file"
+    echo "${padded_script}" $({ time "$PASH_TOP/pa.sh" $PASH_FLAGS -d 1 -w "${width}" --log_file "${pash_log}" ${script}.sh > "$par_outputs_file"; } 2>&1) | tee -a "$par_times_file"
   done
 
   cd ..
@@ -102,7 +102,7 @@ unix50_pash(){
     outputs_file="${outputs_dir}/${script}.${outputs_suffix}"
     pash_log="${pash_logs_dir}/${script}.pash.log"
 
-    echo "${padded_script}" $({ time "$PASH_TOP/pa.sh" --speculation quick_abort --r_split --dgsh_tee -d 1 -w "${width}" --log_file "${pash_log}" ${script}.sh > "$outputs_file"; } 2>&1) | tee -a "$times_file"
+    echo "${padded_script}" $({ time "$PASH_TOP/pa.sh" $PASH_FLAGS -d 1 -w "${width}" --log_file "${pash_log}" ${script}.sh > "$outputs_file"; } 2>&1) | tee -a "$times_file"
   done  
   cd ..
 }
@@ -136,7 +136,7 @@ web-index_pash(){
   pash_log="${pash_logs_dir}/web-index.pash.log"
 
   ## FIXME: There is a bug when running with r_split at the moment. r_wrap cannot execute bash_functions
-  echo web-index.sh: $({ time "$PASH_TOP/pa.sh" --dgsh_tee -d 1 -w "${width}" --log_file "${pash_log}" web-index.sh > "${outputs_file}"; } 2>&1) | tee -a "$times_file"
+  echo web-index.sh: $({ time "$PASH_TOP/pa.sh" $PASH_FLAGS -d 1 -w "${width}" --log_file "${pash_log}" web-index.sh > "${outputs_file}"; } 2>&1) | tee -a "$times_file"
   cd ..
 }
 
@@ -160,7 +160,7 @@ max-temp_pash(){
   echo executing max temp with pash $(date) | tee -a "$times_file"
   outputs_file="${outputs_dir}/max-temp.${outputs_suffix}"
   pash_log="${pash_logs_dir}/max-temp.pash.log"
-  echo mex-temp.sh: $({ time time "$PASH_TOP/pa.sh" --r_split --dgsh_tee -d 1 -w "${width}" --log_file "${pash_log}" max-temp.sh > "${outputs_file}"; } 2>&1) | tee -a "$times_file"
+  echo mex-temp.sh: $({ time time "$PASH_TOP/pa.sh" $PASH_FLAGS -d 1 -w "${width}" --log_file "${pash_log}" max-temp.sh > "${outputs_file}"; } 2>&1) | tee -a "$times_file"
   cd ..
 }
 
@@ -199,7 +199,7 @@ analytics-mts_pash(){
     outputs_file="${outputs_dir}/${script}.${outputs_suffix}"
     pash_log="${pash_logs_dir}/${script}.pash.log"
 
-    echo "${padded_script}" $({ time "$PASH_TOP/pa.sh" --r_split --dgsh_tee -d 1 -w "${width}" --log_file "${pash_log}" ${script}.sh > "$outputs_file"; } 2>&1) | tee -a "$times_file"
+    echo "${padded_script}" $({ time "$PASH_TOP/pa.sh" $PASH_FLAGS -d 1 -w "${width}" --log_file "${pash_log}" ${script}.sh > "$outputs_file"; } 2>&1) | tee -a "$times_file"
   done
   cd ..
 }
@@ -267,7 +267,7 @@ poets_pash(){
     outputs_file="${outputs_dir}/${script}.${outputs_suffix}"
     pash_log="${pash_logs_dir}/${script}.pash.log"
 
-    echo "${padded_script}" $({ time "$PASH_TOP/pa.sh" --r_split --dgsh_tee -d 1 -w "${width}" --log_file "${pash_log}" ${script}.sh > "$outputs_file"; } 2>&1) | tee -a "$times_file"
+    echo "${padded_script}" $({ time "$PASH_TOP/pa.sh" $PASH_FLAGS -d 1 -w "${width}" --log_file "${pash_log}" ${script}.sh > "$outputs_file"; } 2>&1) | tee -a "$times_file"
   done
   cd ..
 }
@@ -343,7 +343,7 @@ dgsh_pash(){
     outputs_file="${outputs_dir}/${script}.${outputs_suffix}"
     pash_log="${pash_logs_dir}/${script}.pash.log"
 
-    echo "${padded_script}" $({ time "$PASH_TOP/pa.sh" --r_split --dgsh_tee -d 1 -w "${width}" --log_file "${pash_log}" ${script}.sh > "$outputs_file"; } 2>&1) | tee -a "$times_file"
+    echo "${padded_script}" $({ time "$PASH_TOP/pa.sh" $PASH_FLAGS -d 1 -w "${width}" --log_file "${pash_log}" ${script}.sh > "$outputs_file"; } 2>&1) | tee -a "$times_file"
   done
   cd ..
 }
@@ -409,7 +409,7 @@ aliases_pash(){
     outputs_file="${outputs_dir}/${script}.${outputs_suffix}"
     pash_log="${pash_logs_dir}/${script}.pash.log"
 
-    echo "${padded_script}" $({ time "$PASH_TOP/pa.sh" --r_split --dgsh_tee -d 1 -w "${width}" --log_file "${pash_log}" ${script}.sh > "$outputs_file"; } 2>&1) | tee -a "$times_file"
+    echo "${padded_script}" $({ time "$PASH_TOP/pa.sh" $PASH_FLAGS -d 1 -w "${width}" --log_file "${pash_log}" ${script}.sh > "$outputs_file"; } 2>&1) | tee -a "$times_file"
   done
   cd ..
 }
@@ -461,7 +461,7 @@ posh_pash(){
     outputs_file="${outputs_dir}/${script}.${outputs_suffix}"
     pash_log="${pash_logs_dir}/${script}.pash.log"
 
-    echo "${padded_script}" $({ time "$PASH_TOP/pa.sh" --r_split --dgsh_tee -d 1 -w "${width}" --log_file "${pash_log}" ${script}.sh > "$outputs_file"; } 2>&1) | tee -a "$times_file"
+    echo "${padded_script}" $({ time "$PASH_TOP/pa.sh" $PASH_FLAGS -d 1 -w "${width}" --log_file "${pash_log}" ${script}.sh > "$outputs_file"; } 2>&1) | tee -a "$times_file"
   done
   cd ..
 }
@@ -508,7 +508,7 @@ bio_pash(){
     outputs_file="${outputs_dir}/${script}.${outputs_suffix}"
     pash_log="${pash_logs_dir}/${script}.pash.log"
 
-    echo "${padded_script}" $({ time "$PASH_TOP/pa.sh" --r_split --dgsh_tee -d 1 -w "${width}" --log_file "${pash_log}" ${script}.sh > "$outputs_file"; } 2>&1) | tee -a "$times_file"
+    echo "${padded_script}" $({ time "$PASH_TOP/pa.sh" $PASH_FLAGS -d 1 -w "${width}" --log_file "${pash_log}" ${script}.sh > "$outputs_file"; } 2>&1) | tee -a "$times_file"
   done
   cd ..
 }

--- a/evaluation/benchmarks/run_all_benchmarks.sh
+++ b/evaluation/benchmarks/run_all_benchmarks.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+## Determines whether the experimental pash flags will be tested. 
+## By default they are not.
+export EXPERIMENTAL=0
+
+for item in $@
+do
+    if [ "--experimental" == "$item" ]; then
+        export EXPERIMENTAL=1
+    fi
+done
+
 ## This script is necessary to ensure that sourcing happens with bash
 source run.seq.sh
 source run.par.sh
@@ -14,6 +25,13 @@ compare_outputs(){
     diff -q "$seq_output" "$pash_output"
   done
 }
+
+if [ "$EXPERIMENTAL" -eq 1 ]; then
+  export PASH_FLAGS="--speculation quick_abort --r_split --dgsh_tee --r_split_batch_size 1000000"
+else
+  export PASH_FLAGS=""
+fi
+
 
 oneliners
 oneliners_pash

--- a/runtime/auto-split.sh
+++ b/runtime/auto-split.sh
@@ -18,6 +18,16 @@ batch_size=$( expr $total_lines / $n_outputs )
 # echo "Number of outputs: $n_outputs"
 # echo "Total Lines: $total_lines"
 # echo "Batch Size: $batch_size"
+
+cleanup()
+{
+    kill -SIGPIPE $split_pid > /dev/null 2>&1
+}
+trap cleanup EXIT
+
+
 # echo "$PASH_TOP/evaluation/tools/split $input $batch_size $outputs"
-$PASH_TOP/runtime/split "$temp" "$batch_size" $outputs
+$PASH_TOP/runtime/split "$temp" "$batch_size" $outputs &
+split_pid=$!
+wait $split_pid
 rm -f $temp

--- a/runtime/dgsh_tee.sh
+++ b/runtime/dgsh_tee.sh
@@ -6,5 +6,12 @@ args=${@:3}
 # Set a default DISH_TOP in this directory if it doesn't exist
 PASH_TOP=${PASH_TOP:-$(git rev-parse --show-toplevel)}
 
-$PASH_TOP/runtime/dgsh-tee -i "$input" -o "$output" $args
+cleanup()
+{
+    kill -SIGPIPE $dgsh_tee_pid > /dev/null 2>&1
+}
+trap cleanup EXIT
 
+$PASH_TOP/runtime/dgsh-tee -i "$input" -o "$output" $args &
+dgsh_tee_pid=$!
+wait $dgsh_tee_pid

--- a/runtime/eager.sh
+++ b/runtime/eager.sh
@@ -7,5 +7,13 @@ intermediate_file=${3?"ERROR: Eager: No intermediate file given"}
 # Set a default DISH_TOP in this directory if it doesn't exist
 PASH_TOP=${PASH_TOP:-$(git rev-parse --show-toplevel)}
 
-$PASH_TOP/runtime/eager "$input" "$output" "$intermediate_file"
+cleanup()
+{
+    kill -SIGPIPE $eager_pid > /dev/null 2>&1
+}
+trap cleanup EXIT
+
+$PASH_TOP/runtime/eager "$input" "$output" "$intermediate_file" &
+eager_pid=$!
+wait $eager_pid
 rm "$intermediate_file"


### PR DESCRIPTION
Some fixes to ensure that tests and evaluation run without experimental components by default.

Note: Do not squash! I have already squashed and different commits correspond to different changes.