### PR TITLE
Braces in printing

### DIFF
--- a/compiler/parser/ceda/ast2shell.py
+++ b/compiler/parser/ceda/ast2shell.py
@@ -177,21 +177,21 @@ def to_string (ast):
 
             return parens (to_string (a) + string_of_redirs (redirs));
         elif (type == "And"):
-            (a1, a2) = params;
+            (a1, a2) = params
 
             return braces(to_string(a1)) + " && " + braces(to_string(a2))
         elif (type == "Or"):
-            (a1, a2) = params;
+            (a1, a2) = params
 
-            return to_string (a1) + " || " + to_string (a2);
+            return braces(to_string(a1)) + " || " + braces(to_string(a2))
         elif (type == "Not"):
-            (a) = params;
+            (a) = params
 
-            return "! " + braces (to_string (a));
+            return "! " + braces(to_string(a))
         elif (type == "Semi"):
-            (a1, a2) = params;
+            (a1, a2) = params
 
-            return to_string (a1) + " \n " + to_string (a2);
+            return braces(to_string(a1)) + " \n " + braces(to_string(a2))
         elif (type == "If"):
             (c, t, e) = params;
             return string_of_if (c, t, e);

--- a/compiler/parser/ceda/ast2shell.py
+++ b/compiler/parser/ceda/ast2shell.py
@@ -179,7 +179,7 @@ def to_string (ast):
         elif (type == "And"):
             (a1, a2) = params;
 
-            return to_string (a1) + " && " + to_string (a2);
+            return braces(to_string(a1)) + " && " + braces(to_string(a2))
         elif (type == "Or"):
             (a1, a2) = params;
 


### PR DESCRIPTION
Python printing causes an issue when running `https://github.com/andromeda/pash/blob/fix-printing-braces/evaluation/intro/demo-spell.sh` because it does not properly add the braces after the `&&` in line 7. Therefore, `exit` in Line 9 is always executed!

@mgree and @thurstond is there any issue with adding braces around everything in the printer? Could we add as many braces to be safe?
