### PR TITLE
Add a top-level tests script

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ Remember to `export` `PASH_TOP` in your startup scripts!
 
 ## Testing
 
-To execute the current tests before committing or pushing code, simply run:
+To execute the current tests before committing and pushing code, simply run:
 
 ```sh
-./run_tests.sh
+./scripts/run_tests.sh
 ```
 
 ## Repo Structure

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ Remember to `export` `PASH_TOP` in your startup scripts!
 To execute the current tests before committing or pushing code, simply run:
 
 ```sh
-cd compiler
-./test_evaluation_scripts.sh
+./run_tests.sh
 ```
 
 ## Repo Structure

--- a/evaluation/intro/input/.gitignore
+++ b/evaluation/intro/input/.gitignore
@@ -1,0 +1,3 @@
+100M.txt
+words
+sorted_words

--- a/evaluation/intro/test.sh
+++ b/evaluation/intro/test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+export PASH_TOP=${PASH_TOP:-$(git rev-parse --show-toplevel --show-superproject-working-tree)}
+
+## TODO: Make the compiler work too.
+bash="bash"
+pash="$PASH_TOP/pa.sh -w 2"
+
+output_dir="$PASH_TOP/evaluation/intro/output"
+mkdir -p "$output_dir"
+
+( cd "$PASH_TOP/evaluation/intro/input"; ./setup.sh ) 
+
+run_test()
+{
+    local test=$1
+
+    echo -n "Running $test..."
+    $bash "$test" > "$output_dir/$test.bash.out"
+    test_bash_ec=$?
+    $pash "$test" > "$output_dir/$test.pash.out"
+    test_pash_ec=$?
+    diff "$output_dir/$test.bash.out" "$output_dir/$test.pash.out"
+    test_diff_ec=$?
+
+    if [ $test_diff_ec -ne 0 ]; then
+        echo -n "$test output mismatch"
+    fi
+    if [ $test_bash_ec -ne $test_pash_ec ]; then
+        echo -n "$test exit code mismatch"
+    fi
+    if [ $test_diff_ec -ne 0 ] || [ $test_bash_ec -ne $test_pash_ec ]; then
+        echo '   FAIL'
+        return 1
+    else
+        echo '   OK'
+        return 0
+    fi
+}
+
+run_test "demo-spell.sh"
+run_test "hello-world.sh"

--- a/evaluation/tests/interface_tests/run.sh
+++ b/evaluation/tests/interface_tests/run.sh
@@ -12,6 +12,12 @@ mkdir -p "$output_dir"
 run_test()
 {
     local test=$1
+
+    if [ "$(type -t $test)" != "function" ]; then
+        echo "$test is not a function!   FAIL"
+        return 1
+    fi
+
     echo -n "Running $test..."
     $test "bash" > "$output_dir/$test.bash.out"
     test_bash_ec=$?
@@ -55,6 +61,14 @@ test3()
     $shell -c 'echo $0 $2 $1' pash 2 3
 }
 
-run_test test1
-run_test test2
-run_test test3
+## We run all tests composed with && to exit on the first that fails
+if [ "$#" -eq 0 ]; then
+    run_test test1 &&
+    run_test test2
+    # run_test test3  # This is commented out at the moment because it doesn't suceed
+else
+    for testname in $@
+    do
+        run_test "$testname"
+    done
+fi

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+export PASH_TOP=${PASH_TOP:-$(git rev-parse --show-toplevel --show-superproject-working-tree)}
+
+( echo "Running intro tests..."; cd "$PASH_TOP/evaluation/intro"; ./test.sh ) &&
+( echo "Running interface tests..."; cd "$PASH_TOP/evaluation/tests/interface_tests"; ./run.sh ) &&
+( echo "Running compiler tests..."; cd "$PASH_TOP/compiler"; ./test_evaluation_scripts.sh )

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-export PASH_TOP=${PASH_TOP:-$(git rev-parse --show-toplevel --show-superproject-working-tree)}
-
-( echo "Running intro tests..."; cd "$PASH_TOP/evaluation/intro"; ./test.sh ) &&
-( echo "Running interface tests..."; cd "$PASH_TOP/evaluation/tests/interface_tests"; ./run.sh ) &&
-( echo "Running compiler tests..."; cd "$PASH_TOP/compiler"; ./test_evaluation_scripts.sh )

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -x e
+
+export PASH_TOP=${PASH_TOP:-$(git rev-parse --show-toplevel --show-superproject-working-tree)}
+
+echo "Running intro tests..."
+cd "$PASH_TOP/evaluation/intro"
+./test.sh
+
+echo "Running interface tests..."
+cd "$PASH_TOP/evaluation/tests/interface_tests"
+./run.sh
+
+echo "Running compiler tests..."
+cd "$PASH_TOP/compiler"
+./test_evaluation_scripts.sh )


### PR DESCRIPTION
This PR adds a top-level testing script and polishes the `interface_tests` testing script.

This testing script can then be used before pushing/merging PRs through a CI.