### PR TITLE
[DRAFT] Parsing assertion failing

### DIFF
--- a/evaluation/tests/interface_tests/heredoc1.sh
+++ b/evaluation/tests/interface_tests/heredoc1.sh
@@ -1,0 +1,3 @@
+cat << foo
+line one
+foo

--- a/evaluation/tests/interface_tests/run.sh
+++ b/evaluation/tests/interface_tests/run.sh
@@ -67,12 +67,19 @@ test4()
     $shell -c 'shift; echo $1 $2' pash 2 3 4 5
 }
 
+test5()
+{
+    local shell=$1
+    $shell heredoc1.sh
+}
+
 ## We run all tests composed with && to exit on the first that fails
 if [ "$#" -eq 0 ]; then
     run_test test1 &&
     run_test test2 &&
     run_test test3 &&
-    run_test test4
+    run_test test4 &&
+    run_test test5
 else
     for testname in $@
     do


### PR DESCRIPTION
The parsing assertion https://github.com/andromeda/pash/blob/main/compiler/parser/ceda/parse_to_ast2.py#L72 fails when executing PaSh on the simple `heredoc1.sh` that is shown below. Note that the script does not end with a newline before EOF.

@thurstond is it reasonable that this assertion fails there?

@mgree what do you think?

Note that this assertion failing is behind 8 POSIX test fails.