### PR TITLE
Loop argument parsing issue

### DIFF
--- a/compiler/ast_to_ir.py
+++ b/compiler/ast_to_ir.py
@@ -492,10 +492,9 @@ def replace_ast_regions(ast_objects, irFileGen, config):
     preprocessed_asts = []
     candidate_dataflow_region = []
     for i, ast_object in enumerate(ast_objects):
-        # log("Preprocessing AST {}".format(i))
-        # log(ast_object)
+        log("Preprocessing AST {}".format(i))
+        log(ast_object)
         ast, original_text, _linno_before, _linno_after = ast_object
-
         ## TODO: Turn the untyped ast to an AstNode
 
         ## Goals: This transformation can approximate in several directions.
@@ -662,6 +661,7 @@ def preprocess_node_subshell(ast_node, irFileGen, config):
 ## TODO: This is not efficient at all since it calls the PaSh runtime everytime the loop is entered.
 ##       We have to find a way to improve that.
 def preprocess_node_for(ast_node, irFileGen, config):
+    log("Ast Node Before:", ast_node)
     preprocessed_body, something_replaced = preprocess_close_node(ast_node.body, irFileGen, config)
     ## TODO: Could there be a problem with the in-place update
     ast_node.body = preprocessed_body
@@ -669,6 +669,7 @@ def preprocess_node_for(ast_node, irFileGen, config):
                                               replace_whole=False,
                                               non_maximal=False,
                                               something_replaced=something_replaced)
+    log("Ast Node After:", ast_node)
     return preprocessed_ast_object
 
 def preprocess_node_while(ast_node, irFileGen, config):

--- a/compiler/ast_to_ir.py
+++ b/compiler/ast_to_ir.py
@@ -492,8 +492,8 @@ def replace_ast_regions(ast_objects, irFileGen, config):
     preprocessed_asts = []
     candidate_dataflow_region = []
     for i, ast_object in enumerate(ast_objects):
-        log("Preprocessing AST {}".format(i))
-        log(ast_object)
+        # log("Preprocessing AST {}".format(i))
+        # log(ast_object)
         ast, original_text, _linno_before, _linno_after = ast_object
         ## TODO: Turn the untyped ast to an AstNode
 
@@ -661,7 +661,6 @@ def preprocess_node_subshell(ast_node, irFileGen, config):
 ## TODO: This is not efficient at all since it calls the PaSh runtime everytime the loop is entered.
 ##       We have to find a way to improve that.
 def preprocess_node_for(ast_node, irFileGen, config):
-    log("Ast Node Before:", ast_node)
     preprocessed_body, something_replaced = preprocess_close_node(ast_node.body, irFileGen, config)
     ## TODO: Could there be a problem with the in-place update
     ast_node.body = preprocessed_body
@@ -669,7 +668,6 @@ def preprocess_node_for(ast_node, irFileGen, config):
                                               replace_whole=False,
                                               non_maximal=False,
                                               something_replaced=something_replaced)
-    log("Ast Node After:", ast_node)
     return preprocessed_ast_object
 
 def preprocess_node_while(ast_node, irFileGen, config):

--- a/compiler/parser/ceda/ast2a.py
+++ b/compiler/parser/ceda/ast2a.py
@@ -120,7 +120,7 @@ def of_node (n_ptr):
         elif (n.type == NFOR):
             return ["For",
                     [n.nfor.linno,
-                     to_arg (n.nfor.args.contents.narg),
+                     to_args (n.nfor.args),
                      of_node (n.nfor.body),
                      n.nfor.var.decode ("charmap")]];
         elif (n.type == NDEFUN):

--- a/compiler/parser/ceda/ast2shell.py
+++ b/compiler/parser/ceda/ast2shell.py
@@ -177,21 +177,21 @@ def to_string (ast):
 
             return parens (to_string (a) + string_of_redirs (redirs));
         elif (type == "And"):
-            (a1, a2) = params;
+            (a1, a2) = params
 
-            return to_string (a1) + " && " + to_string (a2);
+            return braces(to_string(a1)) + " && " + braces(to_string(a2))
         elif (type == "Or"):
-            (a1, a2) = params;
+            (a1, a2) = params
 
-            return to_string (a1) + " || " + to_string (a2);
+            return braces(to_string(a1)) + " || " + braces(to_string(a2))
         elif (type == "Not"):
-            (a) = params;
+            (a) = params
 
-            return "! " + braces (to_string (a));
+            return "! " + braces(to_string(a))
         elif (type == "Semi"):
-            (a1, a2) = params;
+            (a1, a2) = params
 
-            return to_string (a1) + " ; " + to_string (a2);
+            return braces(to_string(a1)) + " \n " + braces(to_string(a2))
         elif (type == "If"):
             (c, t, e) = params;
             return string_of_if (c, t, e);

--- a/compiler/parser/ceda/ast2shell.py
+++ b/compiler/parser/ceda/ast2shell.py
@@ -177,21 +177,21 @@ def to_string (ast):
 
             return parens (to_string (a) + string_of_redirs (redirs));
         elif (type == "And"):
-            (a1, a2) = params
+            (a1, a2) = params;
 
-            return braces(to_string(a1)) + " && " + braces(to_string(a2))
+            return to_string (a1) + " && " + to_string (a2);
         elif (type == "Or"):
-            (a1, a2) = params
+            (a1, a2) = params;
 
-            return braces(to_string(a1)) + " || " + braces(to_string(a2))
+            return to_string (a1) + " || " + to_string (a2);
         elif (type == "Not"):
-            (a) = params
+            (a) = params;
 
-            return "! " + braces(to_string(a))
+            return "! " + braces (to_string (a));
         elif (type == "Semi"):
-            (a1, a2) = params
+            (a1, a2) = params;
 
-            return braces(to_string(a1)) + " \n " + braces(to_string(a2))
+            return to_string (a1) + " ; " + to_string (a2);
         elif (type == "If"):
             (c, t, e) = params;
             return string_of_if (c, t, e);
@@ -209,7 +209,7 @@ def to_string (ast):
         elif (type == "For"):
             (_, a, body, var) = params;
 
-            return "for " + var + " in " + string_of_arg (a) + "; do " + \
+            return "for " + var + " in " + separated (string_of_arg, a) + "; do " + \
                    to_string (body) + "; done";
         elif (type == "Case"):
             (_, a, cs) = params;

--- a/evaluation/tests/interface_tests/loop1.sh
+++ b/evaluation/tests/interface_tests/loop1.sh
@@ -1,0 +1,3 @@
+for idFor1 in A B ; do
+	echo $idFor1
+done

--- a/evaluation/tests/interface_tests/run.sh
+++ b/evaluation/tests/interface_tests/run.sh
@@ -67,12 +67,19 @@ test4()
     $shell -c 'shift; echo $1 $2' pash 2 3 4 5
 }
 
+test6()
+{
+    local shell=$1
+    $shell loop1.sh
+}
+
 ## We run all tests composed with && to exit on the first that fails
 if [ "$#" -eq 0 ]; then
     run_test test1 &&
     run_test test2 &&
     run_test test3 &&
-    run_test test4
+    run_test test4 &&
+    run_test test6
 else
     for testname in $@
     do


### PR DESCRIPTION
The `loop1.sh` testcase (simplified from a POSIX test) is parsed wrongly by pash which only parses the first loop argument `A` and not `B`.

One can reproduce this by running `$PASH_TOP/pa.sh -d 1 loop1.sh` with the added logs in this branch to see that it is a parsing issue.

@thurstond, @mgree do you have any ideas what could be the problem?