### PR TITLE
Pip install fixes

### DIFF
--- a/pa.sh
+++ b/pa.sh
@@ -2,7 +2,7 @@
 
 export PASH_TOP=${PASH_TOP:-${BASH_SOURCE%/*}}
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib/"
-
+export PYTHONPATH=${PYTHON_DEPS:-$PASH_TOP/python_deps}
 if [ "$#" -eq 1 ] && [ "$1" = "--init" ]; then
   $PASH_TOP/compiler/superoptimize.sh
   exit

--- a/pa.sh
+++ b/pa.sh
@@ -2,7 +2,6 @@
 
 export PASH_TOP=${PASH_TOP:-${BASH_SOURCE%/*}}
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib/"
-export PYTHONPATH=${PYTHON_DEPS:-$PASH_TOP/python_deps}
 if [ "$#" -eq 1 ] && [ "$1" = "--init" ]; then
   $PASH_TOP/compiler/superoptimize.sh
   exit

--- a/scripts/distro-deps.sh
+++ b/scripts/distro-deps.sh
@@ -30,7 +30,7 @@ case "$distro" in
      echo "|-- running apt update..."
      sudo apt-get update &> $LOG_DIR/apt_update.log
      echo "|-- running apt install..."
-     sudo apt-get install -y git libtool m4 automake pkg-config libffi-dev python3 python3-pip wamerican-insane bc bsdmainutils &> $LOG_DIR/apt_install.log
+     sudo apt-get install -y git virtualenv libtool m4 automake pkg-config libffi-dev python3 python3-pip wamerican-insane bc bsdmainutils &> $LOG_DIR/apt_install.log
      ;;
    debian*)
      # tested with debian:stable-20210408
@@ -38,17 +38,17 @@ case "$distro" in
      echo "|-- running apt update..."
      apt-get update &> $LOG_DIR/apt_update.log
      echo "|-- running apt install..."
-     apt-get install -y git libtool curl sudo procps m4 automake pkg-config libffi-dev python3 python3-pip wamerican-insane bc bsdmainutils &> $LOG_DIR/apt_install.log
+     apt-get install -y git libtool curl sudo virtualenv procps m4 automake pkg-config libffi-dev python3 python3-pip wamerican-insane bc bsdmainutils &> $LOG_DIR/apt_install.log
      ;;
    fedora*) 
      echo "|-- running dnf install...."
-     dnf install git gcc python3-pip make automake autoconf libtool hostname bc procps -y  &> $LOG_DIR/dnf_install.log
+     dnf install git gcc python3-pip make automake autoconf python-virtualenv libtool hostname bc procps -y  &> $LOG_DIR/dnf_install.log
      ;;
    arch*) 
     echo "Updating mirrors"
     pacman -Sy &> $LOG_DIR/pacman_update.log
      echo "|-- running pacman install...."
-    yes | pacman -S git libtool m4 automake pkg-config python-pip libffi make autoconf gcc sudo inetutils bc
+    yes | pacman -S git libtool m4 automake pkg-config python-pip python-virtualenv libffi make autoconf gcc sudo inetutils bc
     ;;
    *)        echo "unknown distro: '$distro'" ; exit 1 ;;
 esac

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,4 @@
+jsonpickle==1.4.2
+PyYAML==5.4.1
+numpy==1.19.5
+matplotlib==3.3.4

--- a/scripts/setup-pash.sh
+++ b/scripts/setup-pash.sh
@@ -7,9 +7,7 @@ PASH_TOP=${PASH_TOP:-$(git rev-parse --show-toplevel)}
 cd $PASH_TOP
 
 LOG_DIR=$PWD/install_logs
-PYTHON_DEPS=$PWD/python_deps
 mkdir -p $LOG_DIR
-mkdir -p $PYTHON_DEPS
 git submodule init
 git submodule update
 
@@ -40,12 +38,13 @@ echo "Building runtime..."
 cd runtime/
 make &> $LOG_DIR/make.log
 cd ../
-
+virtualenv -p python3 pashenv
+source pashenv/bin/activate
 echo "Installing python dependencies..."
-python3 -m pip install --target=$PYTHON_DEPS/ jsonpickle==1.4.2 &> $LOG_DIR/pip_install_jsonpickle.log
-python3 -m pip install --target=$PYTHON_DEPS/ PyYAML==5.4.1 &> $LOG_DIR/pip_install_pyyaml.log
-python3 -m pip install --target=$PYTHON_DEPS/ numpy==1.19.5 &> $LOG_DIR/pip_install_numpy.log
-python3 -m pip install --target=$PYTHON_DEPS/ matplotlib==3.3.4 &> $LOG_DIR/pip_install_matplotlib.log
+python3 -m pip install  jsonpickle==1.4.2 &> $LOG_DIR/pip_install_jsonpickle.log
+python3 -m pip install  PyYAML==5.4.1 &> $LOG_DIR/pip_install_pyyaml.log
+python3 -m pip install  numpy==1.19.5 &> $LOG_DIR/pip_install_numpy.log
+python3 -m pip install  matplotlib==3.3.4 &> $LOG_DIR/pip_install_matplotlib.log
 
 echo "Generating input files..."
 $PASH_TOP/evaluation/tests/input/setup.sh
@@ -54,5 +53,7 @@ $PASH_TOP/evaluation/tests/input/setup.sh
 echo " * * * "
 echo "Do not forget to export PASH_TOP before using pash: \`export PASH_TOP=$PASH_TOP\`"
 echo "Do not forget to export PYTHONPATH before using pash: \`export PYTHONPATH=$PYTHON_DEPS:$PYTHONPATH\`"
+echo "Do not forget to run \`source pashenv/bin/activate\`!"
+echo "Do not forget to run \`deactivate\` when leaving the pash environment!"
 echo '(optionally, you can update PATH to include it: `export PATH=$PATH:$PASH_TOP`)'
 

--- a/scripts/setup-pash.sh
+++ b/scripts/setup-pash.sh
@@ -7,6 +7,7 @@ PASH_TOP=${PASH_TOP:-$(git rev-parse --show-toplevel)}
 cd $PASH_TOP
 
 LOG_DIR=$PWD/install_logs
+REQ=$PWD/scripts/requirements.txt
 mkdir -p $LOG_DIR
 git submodule init
 git submodule update
@@ -40,11 +41,8 @@ make &> $LOG_DIR/make.log
 cd ../
 virtualenv -p python3 pashenv
 source pashenv/bin/activate
-echo "Installing python dependencies..."
-python3 -m pip install  jsonpickle==1.4.2 &> $LOG_DIR/pip_install_jsonpickle.log
-python3 -m pip install  PyYAML==5.4.1 &> $LOG_DIR/pip_install_pyyaml.log
-python3 -m pip install  numpy==1.19.5 &> $LOG_DIR/pip_install_numpy.log
-python3 -m pip install  matplotlib==3.3.4 &> $LOG_DIR/pip_install_matplotlib.log
+# after we activate the environment
+pip install -r ${REQ} &> $LOG_DIR/pip_reqs.log
 
 echo "Generating input files..."
 $PASH_TOP/evaluation/tests/input/setup.sh

--- a/scripts/setup-pash.sh
+++ b/scripts/setup-pash.sh
@@ -52,8 +52,6 @@ $PASH_TOP/evaluation/tests/input/setup.sh
 # export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib/"
 echo " * * * "
 echo "Do not forget to export PASH_TOP before using pash: \`export PASH_TOP=$PASH_TOP\`"
-echo "Do not forget to export PYTHONPATH before using pash: \`export PYTHONPATH=$PYTHON_DEPS:$PYTHONPATH\`"
+echo '(optionally, you can update PATH to include it: `export PATH=$PATH:$PASH_TOP`)'
 echo "Do not forget to run \`source pashenv/bin/activate\`!"
 echo "Do not forget to run \`deactivate\` when leaving the pash environment!"
-echo '(optionally, you can update PATH to include it: `export PATH=$PATH:$PASH_TOP`)'
-

--- a/scripts/setup-pash.sh
+++ b/scripts/setup-pash.sh
@@ -7,8 +7,9 @@ PASH_TOP=${PASH_TOP:-$(git rev-parse --show-toplevel)}
 cd $PASH_TOP
 
 LOG_DIR=$PWD/install_logs
+PYTHON_DEPS=$PWD/python_deps
 mkdir -p $LOG_DIR
-
+mkdir -p $PYTHON_DEPS
 git submodule init
 git submodule update
 
@@ -41,10 +42,10 @@ make &> $LOG_DIR/make.log
 cd ../
 
 echo "Installing python dependencies..."
-python3 -m pip install jsonpickle &> $LOG_DIR/pip_install_jsonpickle.log
-python3 -m pip install -U PyYAML &> $LOG_DIR/pip_install_pyyaml.log
-python3 -m pip install numpy &> $LOG_DIR/pip_install_numpy.log
-python3 -m pip install matplotlib &> $LOG_DIR/pip_install_matplotlib.log
+python3 -m pip install --target=$PYTHON_DEPS/ jsonpickle==1.4.2 &> $LOG_DIR/pip_install_jsonpickle.log
+python3 -m pip install --target=$PYTHON_DEPS/ PyYAML==5.4.1 &> $LOG_DIR/pip_install_pyyaml.log
+python3 -m pip install --target=$PYTHON_DEPS/ numpy==1.19.5 &> $LOG_DIR/pip_install_numpy.log
+python3 -m pip install --target=$PYTHON_DEPS/ matplotlib==3.3.4 &> $LOG_DIR/pip_install_matplotlib.log
 
 echo "Generating input files..."
 $PASH_TOP/evaluation/tests/input/setup.sh
@@ -52,5 +53,6 @@ $PASH_TOP/evaluation/tests/input/setup.sh
 # export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib/"
 echo " * * * "
 echo "Do not forget to export PASH_TOP before using pash: \`export PASH_TOP=$PASH_TOP\`"
+echo "Do not forget to export PYTHONPATH before using pash: \`export PYTHONPATH=$PYTHON_DEPS:$PYTHONPATH\`"
 echo '(optionally, you can update PATH to include it: `export PATH=$PATH:$PASH_TOP`)'
 


### PR DESCRIPTION
pip install now install packages on $PASH_TOP/python_deps
The packages needed are: 

- jsonpickle==1.4.2
- PyYAML==5.4.1
- numpy==1.19.5
- matplotlib==3.3.4

After setup-pash.sh is executed, an echo message shows the path the user should export
export PYTHONPATH=$PASH_TOP/python_deps